### PR TITLE
[DO NOT MERGE] Forward Fmod Audio to Unity Recorder

### DIFF
--- a/Editor/Sources/RecorderControllerSettings.cs
+++ b/Editor/Sources/RecorderControllerSettings.cs
@@ -166,7 +166,7 @@ namespace UnityEditor.Recorder
             return LoadOrCreate(globalPath);
         }
 
-        internal void ReleaseRecorderSettings()
+        public void ReleaseRecorderSettings()
         {
             foreach (var recorder in m_RecorderSettings)
             {

--- a/Editor/Sources/Recorders/AudioRecorder/AudioRecorder.cs
+++ b/Editor/Sources/Recorders/AudioRecorder/AudioRecorder.cs
@@ -27,7 +27,7 @@ namespace UnityEditor.Recorder
                 return false;
             }
 
-            var audioInput = (AudioInput)m_Inputs[0];
+            var audioInput = (UnityAudioInput)m_Inputs[0];
             var audioAttrsList = new List<AudioTrackAttributes>();
 
             if (audioInput.audioSettings.PreserveAudio)
@@ -67,7 +67,7 @@ namespace UnityEditor.Recorder
 
         protected internal override void RecordFrame(RecordingSession session)
         {
-            var audioInput = (AudioInput)m_Inputs[0];
+            var audioInput = (UnityAudioInput)m_Inputs[0];
 
             if (!audioInput.audioSettings.PreserveAudio)
                 return;

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -248,6 +248,12 @@ namespace UnityEditor.Recorder
 #if UNITY_2019_1_OR_NEWER
         protected override void WriteFrame(AsyncGPUReadbackRequest r, double timestamp)
         {
+            double currentTime = ((AudioInputBase)m_Inputs[1]).audioTime;
+            if (currentTime - timestamp  > 2)
+            {
+                Debug.Log($"(MovieRecorder) Received heavily delayed frame. Requested at [{timestamp}]. Received at [{currentTime}].");
+            }
+
             var format = Settings.GetCurrentEncoder().GetTextureFormat(Settings);
 
             if (Settings.FrameRatePlayback == FrameRatePlayback.Variable)

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -208,7 +208,7 @@ namespace UnityEditor.Recorder
 
             base.RecordFrame(session);
             var audioInput = (AudioInputBase) m_Inputs[1];
-            if (audioInput.audioSettings.PreserveAudio)
+            if (audioInput.audioSettings.PreserveAudio && lastFrame > -1)
                 Settings.m_EncoderManager.AddSamples(m_EncoderHandle, audioInput.mainBuffer);
         }
 
@@ -243,7 +243,7 @@ namespace UnityEditor.Recorder
             WarnOfConcurrentRecorders();
         }
 
-        private long lastFrame = 0;
+        private long lastFrame = -1;
 
 #if UNITY_2019_1_OR_NEWER
         protected override void WriteFrame(AsyncGPUReadbackRequest r, double timestamp)

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -253,8 +253,12 @@ namespace UnityEditor.Recorder
             if (Settings.FrameRatePlayback == FrameRatePlayback.Variable)
             {
                 // The closest media frame to the actual frame's timestamp.
-                int frame = Mathf.RoundToInt((float) (timestamp / (1.0 / (double) m_FrameRate)));
-                MediaTime time = new MediaTime(frame, (uint) m_FrameRate.numerator, (uint) m_FrameRate.denominator);
+                // Convert m_FrameRate using floating-point division. The overloaded cast-to-double operator uses integer division.
+                MediaTime time = new MediaTime
+                {
+                    count = (long) Math.Round(timestamp * m_FrameRate.numerator / m_FrameRate.denominator),
+                    rate = m_FrameRate
+                };
 
                 if (time.count > lastFrame) // If two render frames fall on the same encoding frame, ignore.
                 {

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -108,7 +108,7 @@ namespace UnityEditor.Recorder
                         width, height, videoAttrs.frameRate.numerator,
                         videoAttrs.frameRate.denominator, Settings.fileNameGenerator.BuildAbsolutePath(session)));
 
-            var audioInput = (AudioInput)m_Inputs[1];
+            var audioInput = (AudioInputBase) m_Inputs[1];
             var audioAttrsList = new List<AudioTrackAttributes>();
 
             if (audioInput.audioSettings.PreserveAudio)
@@ -196,7 +196,7 @@ namespace UnityEditor.Recorder
                 throw new Exception("Unsupported number of sources");
 
             base.RecordFrame(session);
-            var audioInput = (AudioInput)m_Inputs[1];
+            var audioInput = (AudioInputBase) m_Inputs[1];
             if (audioInput.audioSettings.PreserveAudio)
                 Settings.m_EncoderManager.AddSamples(m_EncoderHandle, audioInput.mainBuffer);
         }

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -29,6 +29,13 @@ namespace UnityEditor.Recorder
         /// </summary>
         private bool m_RecordingStartedProperly = false;
 
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
+        private static void EnterPlayMode()
+        {
+            s_ConcurrentCount = 0;
+            s_WarnedUserOfConcurrentCount = false;
+        }
+
         protected override TextureFormat ReadbackTextureFormat
         {
             get

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorder.cs
@@ -208,7 +208,7 @@ namespace UnityEditor.Recorder
 
             base.RecordFrame(session);
             var audioInput = (AudioInputBase) m_Inputs[1];
-            if (audioInput.audioSettings.PreserveAudio && lastFrame > -1)
+            if (audioInput.audioSettings.PreserveAudio)
                 Settings.m_EncoderManager.AddSamples(m_EncoderHandle, audioInput.mainBuffer);
         }
 

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorderSettings.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorderSettings.cs
@@ -231,6 +231,24 @@ namespace UnityEditor.Recorder
         }
 
         /// <summary>
+        /// (ASG) Some types in Roslyn can't be loaded via GetTypes. Filter those out.
+        /// </summary>
+        private Type[] GetValidTypes(Assembly a)
+        {
+            Type[] allTypes;
+            try
+            {
+                allTypes = a.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                allTypes = e.Types.Where(t => t != null).ToArray();
+            }
+
+            return allTypes;
+        }
+
+        /// <summary>
         /// Find all the encoders by looking at the content of the current assemblies.
         /// </summary>
         private void RegisterAllEncoders()
@@ -239,7 +257,7 @@ namespace UnityEditor.Recorder
             // For all assemblies find all MediaEncoderRegister
             foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
             {
-                var allTypes = a.GetTypes();
+                var allTypes = GetValidTypes(a);
                 var encoders = allTypes.Where(
                     type => type.IsSubclassOf(typeof(MediaEncoderRegister))
                 );

--- a/Editor/Sources/Recorders/MovieRecorder/MovieRecorderSettings.cs
+++ b/Editor/Sources/Recorders/MovieRecorder/MovieRecorderSettings.cs
@@ -344,7 +344,7 @@ namespace UnityEditor.Recorder
             if (FrameRatePlayback == FrameRatePlayback.Constant &&
                 AudioInputSettings.InputType == typeof(FmodAudioInput))
             {
-                errors.Add("MovieRecorder does not support recording FMOD Audio with a constant video frame rate." +
+                errors.Add("MovieRecorder does not support recording FMOD Audio with a constant video frame rate. " +
                            "Please use a variable frame rate, instead.");
                 ok = false;
             }

--- a/Editor/Sources/Recorders/_Inputs/Audio/AudioInput.cs
+++ b/Editor/Sources/Recorders/_Inputs/Audio/AudioInput.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using FMOD;
 using FMODUnity;
 using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Assertions;
 using Debug = UnityEngine.Debug;
 
@@ -73,6 +72,7 @@ namespace UnityEditor.Recorder.Input
         public abstract int sampleRate { get; }
         public abstract NativeArray<float> mainBuffer { get; }
         public abstract AudioInputSettings audioSettings { get; }
+        public abstract double audioTime { get; }
     }
 
     class UnityAudioInput : AudioInputBase
@@ -125,6 +125,9 @@ namespace UnityEditor.Recorder.Input
             get { return (AudioInputSettings)settings; }
         }
 
+        private long recordedSamples = 0;
+        public override double audioTime => (double) recordedSamples / sampleRate;
+        
         protected internal override void BeginRecording(RecordingSession session)
         {
             m_ChannelCount = new Func<ushort>(() => {
@@ -171,6 +174,7 @@ namespace UnityEditor.Recorder.Input
                 s_BufferManager = new BufferManager(bufferCount, sampleFrameCount, m_ChannelCount);
 
                 AudioRenderer.Render(mainBuffer);
+                recordedSamples += sampleFrameCount;
             }
         }
 
@@ -222,6 +226,9 @@ namespace UnityEditor.Recorder.Input
         public override NativeArray<float> mainBuffer => mMainBuffer;
 
         public override AudioInputSettings audioSettings => (AudioInputSettings) settings;
+
+        private long sampleFrames = 0;
+        public override double audioTime => (double) sampleFrames / sampleRate;
 
         // Keep a reference to the dsp callback so it doesn't get garbage collected.
         private static DSP_READCALLBACK dspCallback;

--- a/Editor/Sources/Recorders/_Inputs/Audio/AudioInput.cs
+++ b/Editor/Sources/Recorders/_Inputs/Audio/AudioInput.cs
@@ -243,8 +243,11 @@ namespace UnityEditor.Recorder.Input
             CheckError(masterDspTail.getChannelFormat(out CHANNELMASK channelMask, out int numChannels,
                 out SPEAKERMODE sourceSpeakerMode));
 
-            Debug.Log(
-                $"(UnityRecorder/FmodAudioInput) Setting DSP to [{channelMask}] [{numChannels}] [{sourceSpeakerMode}]");
+            if (RecorderOptions.VerboseMode)
+            {
+                Debug.Log(
+                    $"(UnityRecorder) Listening to FMOD Audio. Setting DSP to [{channelMask}] [{numChannels}] [{sourceSpeakerMode}]");
+            }
 
             // Create a new DSP with the format of the existing master group.
             CheckError(system.createDSP(ref dspDescription, out dsp));

--- a/Editor/Sources/Recorders/_Inputs/Audio/AudioInputSettings.cs
+++ b/Editor/Sources/Recorders/_Inputs/Audio/AudioInputSettings.cs
@@ -25,7 +25,7 @@ namespace UnityEditor.Recorder.Input
         /// <inheritdoc/>
         protected internal override Type InputType
         {
-            get { return typeof(AudioInput); }
+            get { return typeof(FmodAudioInput); }
         }
 
         /// <inheritdoc/>

--- a/Editor/Sources/RecordersInventory.cs
+++ b/Editor/Sources/RecordersInventory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using System.Reflection;
 using UnityEditor.Recorder.FrameCapturer;
 
 namespace UnityEditor.Recorder
@@ -20,6 +21,24 @@ namespace UnityEditor.Recorder
         static HashSet<RecorderInfo> s_BuiltInRecorderInfos;
         static HashSet<RecorderInfo> s_LegacyRecorderInfos;
 
+        /// <summary>
+        /// (ASG) Some types in Roslyn can't be loaded via GetTypes. Filter those out.
+        /// </summary>
+        private static Type[] GetValidTypes(Assembly a)
+        {
+            Type[] allTypes;
+            try
+            {
+                allTypes = a.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                allTypes = e.Types.Where(t => t != null).ToArray();
+            }
+
+            return allTypes;
+        }
+
         static IEnumerable<KeyValuePair<Type, object[]>> FindRecorders()
         {
             var attribType = typeof(RecorderSettingsAttribute);
@@ -28,7 +47,7 @@ namespace UnityEditor.Recorder
                 Type[] types;
                 try
                 {
-                    types = a.GetTypes();
+                    types = GetValidTypes(a);
                 }
                 catch (Exception)
                 {

--- a/Editor/Sources/RecordingSession.cs
+++ b/Editor/Sources/RecordingSession.cs
@@ -29,7 +29,7 @@ namespace UnityEditor.Recorder
 
         internal bool isRecording
         {
-            get { return recorder.Recording; }
+            get { return recorder?.Recording ?? false; }
         }
 
         public int frameIndex
@@ -199,6 +199,7 @@ namespace UnityEditor.Recorder
                 EndRecording();
 
                 UnityHelpers.Destroy(recorder);
+                recorder = null;
             }
         }
     }

--- a/Editor/Unity.Recorder.Editor.asmdef
+++ b/Editor/Unity.Recorder.Editor.asmdef
@@ -1,13 +1,20 @@
 {
     "name": "Unity.Recorder.Editor",
     "references": [
-      "Unity.Recorder.Base",
-      "Unity.Recorder",
-	  "Unity.Timeline"
+        "Unity.Recorder.Base",
+        "Unity.Recorder",
+        "Unity.Timeline",
+        "Fmod.Runtime"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": true
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Editor/Unity.Recorder.Editor.asmdef
+++ b/Editor/Unity.Recorder.Editor.asmdef
@@ -4,7 +4,8 @@
         "Unity.Recorder.Base",
         "Unity.Recorder",
         "Unity.Timeline",
-        "Fmod.Runtime"
+        "Fmod.Runtime",
+        "Clockwork.Core.Harness"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
Recording game sessions isn't all that useful if you don't have audio. Fmod Audio is fundamentally separate from the rest of the process, so we have to read from Fmod's output and forward it along to the Unity Recorder.

This is a technique I used for Novasentis, and seems to be the recommended way to capture audio from Fmod. See the code for more information. 

I have constructed this branch fairly cleanly, as I expect to rebase these changes whenever Unity Recorder updates. Additionally, I have fixed a number of bugs in Unity Recorder. The overall package is a little bit quickly built.

Known issues:
 - A warning is logged at the end of the gameplay session: "WASAPI Starvation". This is harmless, but kind of annoying. I tried for a few hours to fix this, but no luck. I made a [forum post](https://qa.fmod.com/t/adding-dsp-causes-wasapi-starvation/16393), so hopefully that'll help.


This PR is for reference, but shouldn't be merged. It's already on the submodule master.
